### PR TITLE
Fix ghost hover tooltip appearing after closing fixed tooltip with x button

### DIFF
--- a/client/src/ety/DescendantsTree.tsx
+++ b/client/src/ety/DescendantsTree.tsx
@@ -40,6 +40,7 @@ export default function DescendantsTree(props: DescendantsTreeProps) {
     el: undefined,
     showTimeout: null,
     hideTimeout: null,
+    justDismissed: false,
   };
 
   const svgEls = createMemo(() => {

--- a/client/src/ety/EtymologyTree.tsx
+++ b/client/src/ety/EtymologyTree.tsx
@@ -40,6 +40,7 @@ export default function EtymologyTree(props: EtymologyTreeProps) {
     el: undefined,
     showTimeout: null,
     hideTimeout: null,
+    justDismissed: false,
   };
 
   createEffect(() => {

--- a/client/src/ety/TreeTooltip.tsx
+++ b/client/src/ety/TreeTooltip.tsx
@@ -123,6 +123,9 @@ export default function TreeTooltip(props: TreeTooltipProps) {
                   class="close-button"
                   onClick={() => {
                     props.tooltipRefs.justDismissed = true;
+                    window.setTimeout(() => {
+                      props.tooltipRefs.justDismissed = false;
+                    }, 300);
                     hideTooltip(props.tooltipRefs, props.setShowTooltip);
                   }}
                 >

--- a/client/src/ety/TreeTooltip.tsx
+++ b/client/src/ety/TreeTooltip.tsx
@@ -121,9 +121,10 @@ export default function TreeTooltip(props: TreeTooltipProps) {
               <Show when={props.positionKind() === PositionKind.Fixed}>
                 <button
                   class="close-button"
-                  onClick={() =>
-                    hideTooltip(props.tooltipRefs, props.setShowTooltip)
-                  }
+                  onClick={() => {
+                    props.tooltipRefs.justDismissed = true;
+                    hideTooltip(props.tooltipRefs, props.setShowTooltip);
+                  }}
                 >
                   x
                 </button>

--- a/client/src/ety/tooltip.ts
+++ b/client/src/ety/tooltip.ts
@@ -99,6 +99,7 @@ export interface TooltipRefs {
   el: HTMLDivElement | undefined;
   showTimeout: number | null;
   hideTimeout: number | null;
+  justDismissed: boolean;
 }
 
 export function hideTooltip(

--- a/client/src/ety/tree.ts
+++ b/client/src/ety/tree.ts
@@ -220,6 +220,10 @@ export function setTooltipListeners<T>(
     "pointerenter",
     function (event: PointerEvent, d: BoundedHierarchyPointNode<T>) {
       if (event.pointerType === "mouse") {
+        if (tooltipRefs.justDismissed) {
+          tooltipRefs.justDismissed = false;
+          return;
+        }
         const el = this as unknown as SVGElement;
         window.clearTimeout(tooltipRefs.hideTimeout ?? undefined);
         tooltipRefs.showTimeout = window.setTimeout(() => {


### PR DESCRIPTION
When the x button closed a fixed (centered) tooltip, hideTooltip moved
the tooltip element to (0,0), causing the browser to fire pointerleave
on the tooltip and pointerenter on the tree node now under the cursor.
The pointerenter handler would schedule a new Hover tooltip (no x button)
for that node 100ms later.

Add a justDismissed flag to TooltipRefs. Set it in the x button onClick
before hiding; clear it (and bail) in the pointerenter handler so the
first accidental hover after dismissal is suppressed.

https://claude.ai/code/session_017L3tJVRp39QaLJ6ivWUFec