### PR TITLE
Fix cognates tree reload restoring PIE root instead of searched term

### DIFF
--- a/client/src/state.ts
+++ b/client/src/state.ts
@@ -61,6 +61,19 @@ export function debounce<T extends (...args: any[]) => any>(
   }) as unknown as T;
 }
 
+// Find an item by ID within an InterLangDescendants tree
+function findItemById(
+  nodes: InterLangDescendants[],
+  itemId: number
+): Item | null {
+  for (const node of nodes) {
+    if (node.item.id === itemId) return node.item;
+    const found = findItemById(node.children, itemId);
+    if (found) return found;
+  }
+  return null;
+}
+
 // Collect all langs from a tree (for resolving descLang IDs to names)
 function collectLangsFromEtymology(node: Etymology, out: Map<number, Lang>) {
   out.set(node.item.lang.id, node.item.lang);
@@ -131,7 +144,10 @@ export async function loadFromPath(path: string) {
     const rootItem =
       parsed.kind === TreeKind.Etymology
         ? (cached as Etymology).item
-        : (cached as InterLangDescendants[])[0]?.item ?? dummyItem();
+        : parsed.kind === TreeKind.Cognates
+          ? (findItemById(cached as InterLangDescendants[], parsed.itemId) ??
+            dummyItem())
+          : (cached as InterLangDescendants[])[0]?.item ?? dummyItem();
     const descLangs = resolveDescLangs(parsed.descLangIds, cached, parsed.kind);
     batch(() => {
       setTree(cached);
@@ -168,7 +184,8 @@ export async function loadFromPath(path: string) {
           interLangDescendants(t)
         );
         rootItem =
-          (treeResult as InterLangDescendants[])[0]?.item ?? dummyItem();
+          findItemById(treeResult as InterLangDescendants[], parsed.itemId) ??
+          dummyItem();
         break;
       }
     }

--- a/client/src/state.ts
+++ b/client/src/state.ts
@@ -111,12 +111,12 @@ function resolveDescLangs(
 
 // Apply search field state from loaded tree data (only fills empty fields)
 function applySearchState(
-  itemFromPath: Item,
+  itemFromResult: Item,
   descLangs: Lang[],
   kind: TreeKind
 ) {
-  if (!selectedLang()) setSelectedLang(itemFromPath.lang);
-  if (!selectedItem()) setSelectedItem(itemFromPath);
+  if (!selectedLang()) setSelectedLang(itemFromResult.lang);
+  if (!selectedItem()) setSelectedItem(itemFromResult);
   if (selectedDescLangs().length === 0) setSelectedDescLangs(descLangs);
   setSelectedTreeKind(kind);
 }
@@ -141,7 +141,7 @@ export async function loadFromPath(path: string) {
 
   const cached = treeCache.get(path);
   if (cached) {
-    const itemFromPath =
+    const itemFromResult =
       parsed.kind === TreeKind.Etymology
         ? (cached as Etymology).item
         : parsed.kind === TreeKind.Cognates
@@ -152,9 +152,9 @@ export async function loadFromPath(path: string) {
     batch(() => {
       setTree(cached);
       setLastRequest(
-        new TreeRequest(itemFromPath.lang, itemFromPath, descLangs, parsed.kind)
+        new TreeRequest(itemFromResult.lang, itemFromResult, descLangs, parsed.kind)
       );
-      applySearchState(itemFromPath, descLangs, parsed.kind);
+      applySearchState(itemFromResult, descLangs, parsed.kind);
     });
     return;
   }
@@ -166,24 +166,24 @@ export async function loadFromPath(path: string) {
     const data = await response.json();
 
     let treeResult: Etymology | InterLangDescendants[];
-    let itemFromPath: Item;
+    let itemFromResult: Item;
 
     switch (parsed.kind) {
       case TreeKind.Etymology: {
         treeResult = data as Etymology;
-        itemFromPath = (treeResult as Etymology).item;
+        itemFromResult = (treeResult as Etymology).item;
         break;
       }
       case TreeKind.Descendants: {
         treeResult = [interLangDescendants(data as Descendants)];
-        itemFromPath = (treeResult as InterLangDescendants[])[0].item;
+        itemFromResult = (treeResult as InterLangDescendants[])[0].item;
         break;
       }
       case TreeKind.Cognates: {
         treeResult = (data as Descendants[]).map((t) =>
           interLangDescendants(t)
         );
-        itemFromPath =
+        itemFromResult =
           findItemById(treeResult as InterLangDescendants[], parsed.itemId) ??
           dummyItem();
         break;
@@ -199,9 +199,9 @@ export async function loadFromPath(path: string) {
     batch(() => {
       setTree(treeResult);
       setLastRequest(
-        new TreeRequest(itemFromPath.lang, itemFromPath, descLangs, parsed.kind)
+        new TreeRequest(itemFromResult.lang, itemFromResult, descLangs, parsed.kind)
       );
-      applySearchState(itemFromPath, descLangs, parsed.kind);
+      applySearchState(itemFromResult, descLangs, parsed.kind);
     });
   } catch (error) {
     console.log(error);

--- a/client/src/state.ts
+++ b/client/src/state.ts
@@ -111,12 +111,12 @@ function resolveDescLangs(
 
 // Apply search field state from loaded tree data (only fills empty fields)
 function applySearchState(
-  searchedItem: Item,
+  itemFromPath: Item,
   descLangs: Lang[],
   kind: TreeKind
 ) {
-  if (!selectedLang()) setSelectedLang(searchedItem.lang);
-  if (!selectedItem()) setSelectedItem(searchedItem);
+  if (!selectedLang()) setSelectedLang(itemFromPath.lang);
+  if (!selectedItem()) setSelectedItem(itemFromPath);
   if (selectedDescLangs().length === 0) setSelectedDescLangs(descLangs);
   setSelectedTreeKind(kind);
 }
@@ -141,7 +141,7 @@ export async function loadFromPath(path: string) {
 
   const cached = treeCache.get(path);
   if (cached) {
-    const searchedItem =
+    const itemFromPath =
       parsed.kind === TreeKind.Etymology
         ? (cached as Etymology).item
         : parsed.kind === TreeKind.Cognates
@@ -152,9 +152,9 @@ export async function loadFromPath(path: string) {
     batch(() => {
       setTree(cached);
       setLastRequest(
-        new TreeRequest(searchedItem.lang, searchedItem, descLangs, parsed.kind)
+        new TreeRequest(itemFromPath.lang, itemFromPath, descLangs, parsed.kind)
       );
-      applySearchState(searchedItem, descLangs, parsed.kind);
+      applySearchState(itemFromPath, descLangs, parsed.kind);
     });
     return;
   }
@@ -166,24 +166,24 @@ export async function loadFromPath(path: string) {
     const data = await response.json();
 
     let treeResult: Etymology | InterLangDescendants[];
-    let searchedItem: Item;
+    let itemFromPath: Item;
 
     switch (parsed.kind) {
       case TreeKind.Etymology: {
         treeResult = data as Etymology;
-        searchedItem = (treeResult as Etymology).item;
+        itemFromPath = (treeResult as Etymology).item;
         break;
       }
       case TreeKind.Descendants: {
         treeResult = [interLangDescendants(data as Descendants)];
-        searchedItem = (treeResult as InterLangDescendants[])[0].item;
+        itemFromPath = (treeResult as InterLangDescendants[])[0].item;
         break;
       }
       case TreeKind.Cognates: {
         treeResult = (data as Descendants[]).map((t) =>
           interLangDescendants(t)
         );
-        searchedItem =
+        itemFromPath =
           findItemById(treeResult as InterLangDescendants[], parsed.itemId) ??
           dummyItem();
         break;
@@ -199,9 +199,9 @@ export async function loadFromPath(path: string) {
     batch(() => {
       setTree(treeResult);
       setLastRequest(
-        new TreeRequest(searchedItem.lang, searchedItem, descLangs, parsed.kind)
+        new TreeRequest(itemFromPath.lang, itemFromPath, descLangs, parsed.kind)
       );
-      applySearchState(searchedItem, descLangs, parsed.kind);
+      applySearchState(itemFromPath, descLangs, parsed.kind);
     });
   } catch (error) {
     console.log(error);

--- a/client/src/state.ts
+++ b/client/src/state.ts
@@ -111,12 +111,12 @@ function resolveDescLangs(
 
 // Apply search field state from loaded tree data (only fills empty fields)
 function applySearchState(
-  rootItem: Item,
+  searchedItem: Item,
   descLangs: Lang[],
   kind: TreeKind
 ) {
-  if (!selectedLang()) setSelectedLang(rootItem.lang);
-  if (!selectedItem()) setSelectedItem(rootItem);
+  if (!selectedLang()) setSelectedLang(searchedItem.lang);
+  if (!selectedItem()) setSelectedItem(searchedItem);
   if (selectedDescLangs().length === 0) setSelectedDescLangs(descLangs);
   setSelectedTreeKind(kind);
 }
@@ -141,7 +141,7 @@ export async function loadFromPath(path: string) {
 
   const cached = treeCache.get(path);
   if (cached) {
-    const rootItem =
+    const searchedItem =
       parsed.kind === TreeKind.Etymology
         ? (cached as Etymology).item
         : parsed.kind === TreeKind.Cognates
@@ -152,9 +152,9 @@ export async function loadFromPath(path: string) {
     batch(() => {
       setTree(cached);
       setLastRequest(
-        new TreeRequest(rootItem.lang, rootItem, descLangs, parsed.kind)
+        new TreeRequest(searchedItem.lang, searchedItem, descLangs, parsed.kind)
       );
-      applySearchState(rootItem, descLangs, parsed.kind);
+      applySearchState(searchedItem, descLangs, parsed.kind);
     });
     return;
   }
@@ -166,24 +166,24 @@ export async function loadFromPath(path: string) {
     const data = await response.json();
 
     let treeResult: Etymology | InterLangDescendants[];
-    let rootItem: Item;
+    let searchedItem: Item;
 
     switch (parsed.kind) {
       case TreeKind.Etymology: {
         treeResult = data as Etymology;
-        rootItem = (treeResult as Etymology).item;
+        searchedItem = (treeResult as Etymology).item;
         break;
       }
       case TreeKind.Descendants: {
         treeResult = [interLangDescendants(data as Descendants)];
-        rootItem = (treeResult as InterLangDescendants[])[0].item;
+        searchedItem = (treeResult as InterLangDescendants[])[0].item;
         break;
       }
       case TreeKind.Cognates: {
         treeResult = (data as Descendants[]).map((t) =>
           interLangDescendants(t)
         );
-        rootItem =
+        searchedItem =
           findItemById(treeResult as InterLangDescendants[], parsed.itemId) ??
           dummyItem();
         break;
@@ -199,9 +199,9 @@ export async function loadFromPath(path: string) {
     batch(() => {
       setTree(treeResult);
       setLastRequest(
-        new TreeRequest(rootItem.lang, rootItem, descLangs, parsed.kind)
+        new TreeRequest(searchedItem.lang, searchedItem, descLangs, parsed.kind)
       );
-      applySearchState(rootItem, descLangs, parsed.kind);
+      applySearchState(searchedItem, descLangs, parsed.kind);
     });
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
When loading a cognates tree from a URL path, the rootItem was incorrectly
set to the first item in the returned array (a PIE ancestor root like "*ters")
instead of the originally searched term (e.g. "test"). Fix this by searching
the tree for the item matching the itemId from the URL.

https://claude.ai/code/session_01CH9X3f9BDAoh6Y2tYoSVvk