### PR TITLE
Fix select-all on focus by preventing mouseup caret placement

### DIFF
--- a/client/src/search/ItemSearch.tsx
+++ b/client/src/search/ItemSearch.tsx
@@ -86,7 +86,13 @@ export default function ItemSearch(props: ItemSearchProps) {
           ref={props.setInputRef}
           placeholder="Term..."
           value={selectedItem() ? term(selectedItem()!) : ""}
-          onFocus={(e) => { const el = e.currentTarget; setTimeout(() => el.select(), 0); }}
+          onMouseDown={(e) => {
+            if (document.activeElement !== e.currentTarget) {
+              e.preventDefault();
+              e.currentTarget.focus();
+            }
+          }}
+          onFocus={(e) => e.currentTarget.select()}
         />
       </Combobox.Control>
       <Combobox.Positioner>

--- a/client/src/search/LangSearch.tsx
+++ b/client/src/search/LangSearch.tsx
@@ -107,7 +107,13 @@ export default function LangSearch(props: LangSearchProps) {
           ref={props.setInputRef}
           placeholder="Language..."
           value={selectedLang()?.name ?? ""}
-          onFocus={(e) => { const el = e.currentTarget; setTimeout(() => el.select(), 0); }}
+          onMouseDown={(e) => {
+            if (document.activeElement !== e.currentTarget) {
+              e.preventDefault();
+              e.currentTarget.focus();
+            }
+          }}
+          onFocus={(e) => e.currentTarget.select()}
         />
       </Combobox.Control>
       <Combobox.Positioner>

--- a/client/src/search/MultiLangSearch.tsx
+++ b/client/src/search/MultiLangSearch.tsx
@@ -90,7 +90,13 @@ export default function MultiLangSearch(props: MultiLangSearchProps) {
         <Combobox.Input
           ref={props.setInputRef}
           placeholder="Language(s)..."
-          onFocus={(e) => { const el = e.currentTarget; setTimeout(() => el.select(), 0); }}
+          onMouseDown={(e) => {
+            if (document.activeElement !== e.currentTarget) {
+              e.preventDefault();
+              e.currentTarget.focus();
+            }
+          }}
+          onFocus={(e) => e.currentTarget.select()}
         />
       </Combobox.Control>
       <Combobox.Positioner>


### PR DESCRIPTION
The previous approaches (synchronous select() and setTimeout select())
both failed because the browser's mouseup event places the caret at
the click position, destroying the selection. Instead, use
preventDefault() on mousedown to suppress the browser's default caret
placement behavior, then manually focus and select in onFocus.

https://claude.ai/code/session_014hVNLPsLMhpYwfjg8cW88f